### PR TITLE
Correct Ubuntu labels in params.pp

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,17 +1,16 @@
 # = Class: git::params
 #
 class git::params {
-  case $operatingsystem {
+  case $::operatingsystem {
     'Debian': { $packages = 'git' }
-    'Ubuntu': { $packages = 'git-core' }
     'Ubuntu': {
-      case $operatingsystemrelease {
+      case $::operatingsystemrelease {
         'Hardy', 'Lucid': { $packages = 'git-core' }
         default: { $packages = 'git' }
       }
     }
-   'CentOS', 'SLES', 'Ubuntu', 'RedHat', 'Fedora': { $packages = 'git' }
+    'CentOS', 'SLES', 'RedHat', 'Fedora': { $packages = 'git' }
     'FreeBSD': { $packages = 'devel/git' }
-    default:   { fail("No git package known for operating system ${operatingsystem}") }
+    default:   { fail("No git package known for operating system ${::operatingsystem}") }
   }
 }

--- a/spec/classes/git/init_spec.rb
+++ b/spec/classes/git/init_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'git' do
+  describe 'operating system is Ubuntu' do
+    describe 'release is Lucid' do
+      let(:facts) { { :operatingsystem => 'Ubuntu', :operatingsystemrelease => 'Lucid' } }
+      it 'should include git-core' do
+        should contain_package('git-core')
+      end
+    end  
+
+    describe 'release is Saucy' do
+      let(:facts) { { :operatingsystem => 'Ubuntu', :operatingsystemrelease => 'Saucy' } }
+      it 'should include git' do
+        should contain_package('git')
+      end
+    end
+  end
+
+  describe 'operating system is CentOS' do
+    let(:facts) { { :operatingsystem => 'CentOS' } }
+    it 'should include git' do
+      should contain_package('git')
+    end
+  end
+
+  describe 'operating system is MINIX' do
+    let(:facts) { { :operatingsystem => 'MINIX'} }
+
+    it do
+      expect {
+        should contain_package('git')
+      }.to raise_error(Puppet::Error, /No git package known for operating system MINIX/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
The operatingsystem case statement in params.pp had the same label multiple times, which led to some narly code.  I added a puppet-rspec test to verify the code did not behave as expected.  Then I corrected the code by removing the multiple labels and set it to sane values.  The code now passes the test that I added.
