### PR TITLE
(maint) Quote mode parameters

### DIFF
--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -7,7 +7,7 @@ define git::hook (
 
   file { "${git_dir}/hooks/${hook}":
     owner   => $owner,
-    mode    => 700,
+    mode    => '0700',
     content => $content,
   }
 


### PR DESCRIPTION
This quotes the `mode` parameter on the `file` resource in the
`git::hook` class. Without this change, the manifest does not work with
puppet 4.